### PR TITLE
Use compression lib to gzip files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,17 +1,18 @@
 {
   "name": "t3tr0s",
-  "homepage":"https://github.com/imalooney/t3tr0s",
-  "license":"MIT",
+  "homepage": "https://github.com/imalooney/t3tr0s",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/imalooney/t3tr0s.git"
   },
   "dependencies": {
-    "express" : "4.1.x",
+    "express": "4.1.x",
     "grunt": "0.4.x",
     "grunt-contrib-less": "0.6.4",
     "grunt-contrib-watch": "0.5.3",
     "moment": "2.6.0",
-    "socket.io" : "1.0.x"
+    "socket.io": "1.0.x",
+    "compression": "^1.0.10"
   }
 }

--- a/src/server/core.cljs
+++ b/src/server/core.cljs
@@ -16,6 +16,7 @@
 ;;------------------------------------------------------------------------------
 
 (def express (js/require "express"))
+(def compression (js/require "compression"))
 (def http    (js/require "http"))
 (def socket  (js/require "socket.io"))
 
@@ -271,7 +272,7 @@
   ; Call score update events.
   (if (contains? data :score)
     (on-score-update io))
-  
+
   ; If player should be visible on dashboard, then emit to dashboard.
   (if (contains? data :board)
     (.. io (to "dashboard")
@@ -420,6 +421,7 @@
 
     ; configure express app
     (doto app
+      (.use (compression))
       (.get "/" (fn [req res] (.send res (html/page-shell))))
       (.use (.static express (str js/__dirname "/public"))))
 


### PR DESCRIPTION
I added the gzip compress to the Express 4.x server by using the `compression` :hammer: library.

_NOTE: Remember to run `npm install` to ensure that the compression library is downloaded._
## ![screen shot 2014-08-06 at 12 38 32 am](https://cloud.githubusercontent.com/assets/28176/3822688/533fda86-1d2c-11e4-81bb-ecc8b934cfe2.png)

![screen shot 2014-08-06 at 12 39 20 am](https://cloud.githubusercontent.com/assets/28176/3822689/56b0e4e4-1d2c-11e4-87d0-a8d158b6c993.png)

Fixes #24 @imalooney
